### PR TITLE
Add platformio configuration for clock.

### DIFF
--- a/clock/arduino/platformio.ini
+++ b/clock/arduino/platformio.ini
@@ -1,0 +1,23 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = espressif32
+board = tinypico
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    knolleary/PubSubClient
+    bblanchon/ArduinoJson
+    smougenot/TM1637
+    adafruit/Adafruit NeoPixel


### PR DESCRIPTION
This add the platformio config for the 'clock' project.

To compile from the command line using platformio CLI:
  pio run
To compile + upload:
  pio run -t upload
To monitor serial port output:
  pio device monitor